### PR TITLE
Fix winding order when input is y-down

### DIFF
--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -168,7 +168,8 @@ class VectorTile:
 
         parts = []
         for part in shape.geoms:
-            part = self.enforce_polygon_winding_order(part, y_coord_down, n_try)
+            part = self.enforce_polygon_winding_order(
+                part, y_coord_down, n_try)
             if part is not None and not part.is_empty:
                 parts.append(part)
 

--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -97,12 +97,12 @@ class VectorTile:
             if quantize_bounds:
                 shape = self.quantize(shape, quantize_bounds)
 
-            shape = self.enforce_winding_order(shape)
+            shape = self.enforce_winding_order(shape, y_coord_down)
 
             if shape is not None and not shape.is_empty:
                 self.addFeature(feature, shape, y_coord_down)
 
-    def enforce_winding_order(self, shape, n_try=1):
+    def enforce_winding_order(self, shape, y_coord_down, n_try=1):
         if shape.type == 'MultiPolygon':
             # If we are a multipolygon, we need to ensure that the
             # winding orders of the consituent polygons are
@@ -111,7 +111,8 @@ class VectorTile:
             # exterior ones, and all interior rings need to follow
             # the exterior one. This is how the end of one polygon
             # and the beginning of another are signaled.
-            shape = self.enforce_multipolygon_winding_order(shape, n_try)
+            shape = self.enforce_multipolygon_winding_order(
+                shape, y_coord_down, n_try)
 
         elif shape.type == 'Polygon':
             # Ensure that polygons are also oriented with the
@@ -122,7 +123,8 @@ class VectorTile:
             # Note that while the Y axis flips, we also invert the
             # Y coordinate to get the tile-local value, which means
             # the clockwise orientation is unchanged.
-            shape = self.enforce_polygon_winding_order(shape, n_try)
+            shape = self.enforce_polygon_winding_order(
+                shape, y_coord_down, n_try)
 
         # other shapes just get passed through
         return shape
@@ -139,7 +141,7 @@ class VectorTile:
 
         return transform(fn, shape)
 
-    def handle_shape_validity(self, shape, n_try):
+    def handle_shape_validity(self, shape, y_coord_down, n_try):
         if shape.is_valid:
             return shape
 
@@ -156,16 +158,17 @@ class VectorTile:
                 # altered the geometry. We'll run through the process
                 # again, but keep track of which attempt we are on to
                 # terminate the recursion.
-                shape = self.enforce_winding_order(shape, n_try + 1)
+                shape = self.enforce_winding_order(
+                    shape, y_coord_down, n_try + 1)
 
         return shape
 
-    def enforce_multipolygon_winding_order(self, shape, n_try):
+    def enforce_multipolygon_winding_order(self, shape, y_coord_down, n_try):
         assert shape.type == 'MultiPolygon'
 
         parts = []
         for part in shape.geoms:
-            part = self.enforce_polygon_winding_order(part, n_try)
+            part = self.enforce_polygon_winding_order(part, y_coord_down, n_try)
             if part is not None and not part.is_empty:
                 parts.append(part)
 
@@ -177,10 +180,11 @@ class VectorTile:
         else:
             oriented_shape = MultiPolygon(parts)
 
-        oriented_shape = self.handle_shape_validity(oriented_shape, n_try)
+        oriented_shape = self.handle_shape_validity(
+            oriented_shape, y_coord_down, n_try)
         return oriented_shape
 
-    def enforce_polygon_winding_order(self, shape, n_try):
+    def enforce_polygon_winding_order(self, shape, y_coord_down, n_try):
         assert shape.type == 'Polygon'
 
         def fn(point):
@@ -193,8 +197,10 @@ class VectorTile:
         if len(shape.interiors) > 0:
             rings = [apply_map(fn, ring.coords) for ring in shape.interiors]
 
-        oriented_shape = orient(Polygon(exterior, rings), sign=-1.0)
-        oriented_shape = self.handle_shape_validity(oriented_shape, n_try)
+        sign = 1.0 if y_coord_down else -1.0
+        oriented_shape = orient(Polygon(exterior, rings), sign=sign)
+        oriented_shape = self.handle_shape_validity(
+            oriented_shape, y_coord_down, n_try)
         return oriented_shape
 
     def _load_geometry(self, geometry_spec):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -589,3 +589,25 @@ class LowLevelEncodingTestCase(unittest.TestCase):
         self.assertEqual(1, len(tile.layer.features))
         f = tile.layer.features[0]
         self.assertEqual(expected_commands, list(f.geometry))
+
+    def test_issue_57(self):
+        from mapbox_vector_tile.encoder import VectorTile
+        # example from issue:
+        # https://github.com/tilezen/mapbox-vector-tile/issues/57
+        input_geometry = 'POLYGON ((2 2, 5 4, 2 6, 2 2))'
+        expected_commands = [
+            9,      # 1 x move to
+            4,   4, #             +2,+2
+            18,     # 2 x line to
+            6,   4, #             +3,+2
+            5,   4, #             -3,+2
+            15      # 1 x close path
+        ]
+
+        tile = VectorTile(4096)
+        tile.addFeatures([dict(geometry=input_geometry)],
+                         'example_layer', quantize_bounds=None,
+                         y_coord_down=True)
+        self.assertEqual(1, len(tile.layer.features))
+        f = tile.layer.features[0]
+        self.assertEqual(expected_commands, list(f.geometry))

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -511,33 +511,34 @@ class LowLevelEncodingTestCase(unittest.TestCase):
         from mapbox_vector_tile.encoder import VectorTile
         # example from spec:
         # https://github.com/mapbox/vector-tile-spec/tree/master/2.1#4356-example-multi-polygon
-        # note that examples are in **tile local coordinates** which are y-down.
+        # note that examples are in **tile local coordinates** which are
+        # y-down.
         input_geometry = 'MULTIPOLYGON (' + \
                          '((0 0, 10 0, 10 10, 0 10, 0 0)),' + \
                          '((11 11, 20 11, 20 20, 11 20, 11 11),' + \
-                        ' (13 13, 13 17, 17 17, 17 13, 13 13)))'
+                         ' (13 13, 13 17, 17 17, 17 13, 13 13)))'
         expected_commands = [
-            9,      # 1 x move to
-            0,   0, #             +0,+0
-            26,     # 3 x line to
-            20,  0, #             +10,+0
-            0,  20, #             +0,+10
-            19,  0, #             -10,+0
-            15,     # 1 x close path
-            9,      # 1 x move to
-            22,  2, #             +11,+1
-            26,     # 3 x line to
-            18,  0, #             +9,+0
-            0,  18, #             +0,+9
-            17,  0, #             -9,+0
-            15,     # 1 x close path
-            9,      # 1 x move to
-            4,  13, #             +2,-7
-            26,     # 3 x line to
-            0,   8, #             +0,+4
-            8,   0, #             +4,+0
-            0,   7, #             +0,-4
-            15      # 1 x close path
+            9,       # 1 x move to
+            0,   0,  # ........... +0,+0
+            26,      # 3 x line to
+            20,  0,  # ........... +10,+0
+            0,  20,  # ........... +0,+10
+            19,  0,  # ........... -10,+0
+            15,      # 1 x close path
+            9,       # 1 x move to
+            22,  2,  # ........... +11,+1
+            26,      # 3 x line to
+            18,  0,  # ........... +9,+0
+            0,  18,  # ........... +0,+9
+            17,  0,  # ........... -9,+0
+            15,      # 1 x close path
+            9,       # 1 x move to
+            4,  13,  # ........... +2,-7
+            26,      # 3 x line to
+            0,   8,  # ........... +0,+4
+            8,   0,  # ........... +4,+0
+            0,   7,  # ........... +0,-4
+            15       # 1 x close path
         ]
 
         tile = VectorTile(4096)
@@ -557,29 +558,29 @@ class LowLevelEncodingTestCase(unittest.TestCase):
         input_geometry = 'MULTIPOLYGON (' + \
                          '((0 20, 10 20, 10 10, 0 10, 0 20)),' + \
                          '((11 9, 20 9, 20 0, 11 0, 11 9),' + \
-                        ' (13 7, 13 3, 17 3, 17 7, 13 7)))'
+                         ' (13 7, 13 3, 17 3, 17 7, 13 7)))'
         expected_commands = [
-            9,      # 1 x move to
-            0,   0, #             +0,+0
-            26,     # 3 x line to
-            20,  0, #             +10,+0
-            0,  20, #             +0,+10
-            19,  0, #             -10,+0
-            15,     # 1 x close path
-            9,      # 1 x move to
-            22,  2, #             +11,+1
-            26,     # 3 x line to
-            18,  0, #             +9,+0
-            0,  18, #             +0,+9
-            17,  0, #             -9,+0
-            15,     # 1 x close path
-            9,      # 1 x move to
-            4,  13, #             +2,-7
-            26,     # 3 x line to
-            0,   8, #             +0,+4
-            8,   0, #             +4,+0
-            0,   7, #             +0,-4
-            15      # 1 x close path
+            9,       # 1 x move to
+            0,   0,  # ........... +0,+0
+            26,      # 3 x line to
+            20,  0,  # ........... +10,+0
+            0,  20,  # ........... +0,+10
+            19,  0,  # ........... -10,+0
+            15,      # 1 x close path
+            9,       # 1 x move to
+            22,  2,  # ........... +11,+1
+            26,      # 3 x line to
+            18,  0,  # ........... +9,+0
+            0,  18,  # ........... +0,+9
+            17,  0,  # ........... -9,+0
+            15,      # 1 x close path
+            9,       # 1 x move to
+            4,  13,  # ........... +2,-7
+            26,      # 3 x line to
+            0,   8,  # ........... +0,+4
+            8,   0,  # ........... +4,+0
+            0,   7,  # ........... +0,-4
+            15       # 1 x close path
         ]
 
         tile = VectorTile(20)
@@ -596,12 +597,12 @@ class LowLevelEncodingTestCase(unittest.TestCase):
         # https://github.com/tilezen/mapbox-vector-tile/issues/57
         input_geometry = 'POLYGON ((2 2, 5 4, 2 6, 2 2))'
         expected_commands = [
-            9,      # 1 x move to
-            4,   4, #             +2,+2
-            18,     # 2 x line to
-            6,   4, #             +3,+2
-            5,   4, #             -3,+2
-            15      # 1 x close path
+            9,       # 1 x move to
+            4,   4,  # ........... +2,+2
+            18,      # 2 x line to
+            6,   4,  # ........... +3,+2
+            5,   4,  # ........... -3,+2
+            15       # 1 x close path
         ]
 
         tile = VectorTile(4096)


### PR DESCRIPTION
The library accepts both y-up and y-down orientations for input polygons, and attempts to re-orient them so that the winding order is correct according to the Mapbox vector tile specification.

There was a bug in the routine for orienting the polygons, where it did not account for whether the input polygon was already in a y-down coordinate system and therefore should already show a
positive sign.

In addition, tests have been added based directly on the [examples](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#435-example-geometry-encodings) in the Mapbox vector tile specification and the example from the report in #57, which hopefully ensure that the winding order behaviour is compliant.

Connects to #57.

@rmarianski could you review, please?