### PR TITLE
fixed #61

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Also note that the spec allows the extents to be modified, even though they are 
 
 ### Quantization
 
-The encoder also has options to quantize the data for you via the `quantize_bounds` option. When encoding, pass in the bounds in the form (minx, maxx, miny, maxy) and the coordinates will be scaled appropriately during encoding.
+The encoder also has options to quantize the data for you via the `quantize_bounds` option. When encoding, pass in the bounds in the form (minx, miny, maxx, maxy) and the coordinates will be scaled appropriately during encoding.
 
 ```python
 mapbox_vector_tile.encode([


### PR DESCRIPTION
Just changes a line in the documentation (`README.md`) about the use of `quantize_bounds` when encoding, see #61.