### PR TITLE
Attempt to make making valid more robust

### DIFF
--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -1,3 +1,4 @@
+from mapbox_vector_tile.polygon import make_it_valid
 from math import fabs
 from numbers import Number
 from past.builtins import long
@@ -7,7 +8,6 @@ from shapely.geometry.base import BaseGeometry
 from shapely.geometry.multipolygon import MultiPolygon
 from shapely.geometry.polygon import orient
 from shapely.geometry.polygon import Polygon
-from shapely.geometry.polygon import LinearRing
 from shapely.ops import transform
 from shapely.wkb import loads as load_wkb
 from shapely.wkt import loads as load_wkt
@@ -34,105 +34,8 @@ def on_invalid_geometry_ignore(shape):
     return None
 
 
-def reverse_ring(shape):
-    assert shape.type == 'LinearRing'
-    return LinearRing(list(shape.coords)[::-1])
-
-
-def reverse_polygon(shape):
-    assert shape.type == 'Polygon'
-
-    exterior = reverse_ring(shape.exterior)
-    interiors = [reverse_ring(r) for r in shape.interiors]
-
-    return Polygon(exterior, interiors)
-
-
-def make_valid_polygon_flip(shape):
-    assert shape.type == 'Polygon'
-    # to handle cases where the area of the polygon is zero, we need to
-    # manually reverse the coords in the polygon, then buffer(0) it to make it
-    # valid in reverse, then reverse them again to get back to the original,
-    # intended orientation.
-
-    flipped = reverse_polygon(shape)
-    fixed = flipped.buffer(0)
-
-    if fixed.is_empty:
-        return None
-    else:
-        if fixed.type == 'Polygon':
-            return reverse_polygon(fixed)
-        elif fixed.type == 'MultiPolygon':
-            flipped_geoms = []
-            for geom in fixed.geoms:
-                reversed_geom = reverse_polygon(geom)
-                flipped_geoms.append(reversed_geom)
-            return MultiPolygon(flipped_geoms)
-
-
-def area_bounds(shape):
-    if shape.is_empty:
-        return 0
-
-    elif shape.type == 'MultiPolygon':
-        area = 0
-        for geom in shape.geoms:
-            area += area_bounds(geom)
-        return area
-
-    elif shape.type == 'Polygon':
-        minx, miny, maxx, maxy = shape.bounds
-        area = (maxx - minx) * (maxy - miny)
-        return area
-
-    else:
-        assert 'area_bounds: invalid shape type: %s' % shape.type
-
-
-def make_valid_polygon(shape):
-    prev_area = area_bounds(shape)
-    new_shape = shape.buffer(0)
-    assert new_shape.is_valid, \
-        'buffer(0) did not make geometry valid. old shape: %s' % shape.wkt
-    new_area = area_bounds(new_shape)
-
-    if new_area < 0.9 * prev_area:
-        alt_shape = make_valid_polygon_flip(shape)
-        if alt_shape:
-            new_shape = new_shape.union(alt_shape)
-
-    return new_shape
-
-
-def make_valid_multipolygon(shape):
-    new_g = []
-
-    for g in shape.geoms:
-        if g.is_empty:
-            continue
-
-        valid_g = on_invalid_geometry_make_valid(g)
-
-        if valid_g.type == 'MultiPolygon':
-            new_g.extend(valid_g.geoms)
-        else:
-            new_g.append(valid_g)
-
-    return MultiPolygon(new_g)
-
-
 def on_invalid_geometry_make_valid(shape):
-    if shape.is_empty:
-        return shape
-
-    elif shape.type == 'MultiPolygon':
-        shape = make_valid_multipolygon(shape)
-
-    elif shape.type == 'Polygon':
-        shape = make_valid_polygon(shape)
-
-    return shape
+    return make_it_valid(shape)
 
 
 class VectorTile:

--- a/mapbox_vector_tile/polygon.py
+++ b/mapbox_vector_tile/polygon.py
@@ -5,11 +5,22 @@ import pyclipper
 
 
 def _reverse_ring(shape):
+    """
+    Reverse a LinearRing. A counter-clockwise ring given as input would return
+    a clockwise ring as output. This should reverse the sign of the ring.
+    """
+
     assert shape.geom_type == 'LinearRing'
     return LinearRing(list(shape.coords)[::-1])
 
 
 def _reverse_polygon(shape):
+    """
+    Reverse a Polygon, returning a polygon with the same coordinates in the
+    reverse order. This means the returned polygon should have an area equal to
+    the negative area of the input polygon.
+    """
+
     assert shape.geom_type == 'Polygon'
 
     exterior = _reverse_ring(shape.exterior)
@@ -19,6 +30,12 @@ def _reverse_polygon(shape):
 
 
 def _coords(shape):
+    """
+    Return a list of lists of coordinates of the polygon. The list consists
+    firstly of the list of exterior coordinates followed by zero or more lists
+    of any interior coordinates.
+    """
+
     assert shape.geom_type == 'Polygon'
     coords = [list(shape.exterior.coords)]
     for interior in shape.interiors:
@@ -27,6 +44,13 @@ def _coords(shape):
 
 
 def make_valid_pyclipper(shape):
+    """
+    Use the pyclipper library to union a polygon with its reversed polygon. The
+    result should contain all parts of the polygon and be consistently
+    oriented. The pyclipper library is robust, and uses integer coordinates, so
+    should not produce any additional degeneracies.
+    """
+
     pc = pyclipper.Pyclipper()
 
     try:
@@ -50,6 +74,19 @@ def make_valid_pyclipper(shape):
 
 
 def make_valid_polygon(shape):
+    """
+    Make a polygon valid. Polygons can be invalid in many ways, such as
+    self-intersection, self-touching and degeneracy. This process attempts to
+    make a polygon valid while retaining as much of its extent or area as
+    possible.
+
+    First, we call pyclipper to robustly union the polygon with its reverse.
+    This might result in polygons which still have degeneracies according to
+    the OCG standard of validity - as pyclipper does not consider these to be
+    invalid. Therefore we follow by using the `buffer(0)` technique to attempt
+    to remove any remaining degeneracies.
+    """
+
     assert shape.geom_type == 'Polygon'
 
     clipped_shape = make_valid_pyclipper(shape)
@@ -78,6 +115,10 @@ def make_valid_multipolygon(shape):
 
 
 def make_it_valid(shape):
+    """
+    Attempt to make any polygon or multipolygon valid.
+    """
+
     if shape.is_empty:
         return shape
 

--- a/mapbox_vector_tile/polygon.py
+++ b/mapbox_vector_tile/polygon.py
@@ -68,7 +68,7 @@ def make_valid_pyclipper(shape):
     if len(result) == 1:
         shape = Polygon(result[0])
     else:
-        shape = MultiPolygon(result)
+        shape = MultiPolygon([Polygon(r) for r in result])
 
     return shape
 

--- a/mapbox_vector_tile/polygon.py
+++ b/mapbox_vector_tile/polygon.py
@@ -1,76 +1,62 @@
 from shapely.geometry.multipolygon import MultiPolygon
 from shapely.geometry.polygon import Polygon
 from shapely.geometry.polygon import LinearRing
+import pyclipper
 
 
-def reverse_ring(shape):
-    assert shape.type == 'LinearRing'
+def _reverse_ring(shape):
+    assert shape.geom_type == 'LinearRing'
     return LinearRing(list(shape.coords)[::-1])
 
 
-def reverse_polygon(shape):
-    assert shape.type == 'Polygon'
+def _reverse_polygon(shape):
+    assert shape.geom_type == 'Polygon'
 
-    exterior = reverse_ring(shape.exterior)
-    interiors = [reverse_ring(r) for r in shape.interiors]
+    exterior = _reverse_ring(shape.exterior)
+    interiors = [_reverse_ring(r) for r in shape.interiors]
 
     return Polygon(exterior, interiors)
 
 
-def make_valid_polygon_flip(shape):
-    assert shape.type == 'Polygon'
-    # to handle cases where the area of the polygon is zero, we need to
-    # manually reverse the coords in the polygon, then buffer(0) it to make it
-    # valid in reverse, then reverse them again to get back to the original,
-    # intended orientation.
+def _coords(shape):
+    assert shape.geom_type == 'Polygon'
+    coords = [list(shape.exterior.coords)]
+    for interior in shape.interiors:
+        coords.append(list(interior.coords))
+    return coords
 
-    flipped = reverse_polygon(shape)
-    fixed = flipped.buffer(0)
 
-    if fixed.is_empty:
-        return None
+def make_valid_pyclipper(shape):
+    pc = pyclipper.Pyclipper()
+
+    try:
+        r_shape = _reverse_polygon(shape)
+
+        pc.AddPaths(_coords(shape), pyclipper.PT_CLIP, True)
+        pc.AddPaths(_coords(r_shape), pyclipper.PT_SUBJECT, True)
+
+        result = pc.Execute(pyclipper.CT_UNION, pyclipper.PFT_EVENODD,
+                            pyclipper.PFT_EVENODD)
+
+    except pyclipper.ClipperException:
+        return MultiPolygon([])
+
+    if len(result) == 1:
+        shape = Polygon(result[0])
     else:
-        if fixed.type == 'Polygon':
-            return reverse_polygon(fixed)
-        elif fixed.type == 'MultiPolygon':
-            flipped_geoms = []
-            for geom in fixed.geoms:
-                reversed_geom = reverse_polygon(geom)
-                flipped_geoms.append(reversed_geom)
-            return MultiPolygon(flipped_geoms)
+        shape = MultiPolygon(result)
 
-
-def area_bounds(shape):
-    if shape.is_empty:
-        return 0
-
-    elif shape.type == 'MultiPolygon':
-        area = 0
-        for geom in shape.geoms:
-            area += area_bounds(geom)
-        return area
-
-    elif shape.type == 'Polygon':
-        minx, miny, maxx, maxy = shape.bounds
-        area = (maxx - minx) * (maxy - miny)
-        return area
-
-    else:
-        assert 'area_bounds: invalid shape type: %s' % shape.type
+    return shape
 
 
 def make_valid_polygon(shape):
-    prev_area = area_bounds(shape)
-    new_shape = shape.buffer(0)
+    assert shape.geom_type == 'Polygon'
+
+    clipped_shape = make_valid_pyclipper(shape)
+    new_shape = clipped_shape.buffer(0)
+
     assert new_shape.is_valid, \
         'buffer(0) did not make geometry valid. old shape: %s' % shape.wkt
-    new_area = area_bounds(new_shape)
-
-    if new_area < 0.9 * prev_area:
-        alt_shape = make_valid_polygon_flip(shape)
-        if alt_shape:
-            new_shape = new_shape.union(alt_shape)
-
     return new_shape
 
 
@@ -81,7 +67,7 @@ def make_valid_multipolygon(shape):
         if g.is_empty:
             continue
 
-        valid_g = on_invalid_geometry_make_valid(g)
+        valid_g = make_valid_polygon(g)
 
         if valid_g.type == 'MultiPolygon':
             new_g.extend(valid_g.geoms)

--- a/mapbox_vector_tile/polygon.py
+++ b/mapbox_vector_tile/polygon.py
@@ -1,0 +1,104 @@
+from shapely.geometry.multipolygon import MultiPolygon
+from shapely.geometry.polygon import Polygon
+from shapely.geometry.polygon import LinearRing
+
+
+def reverse_ring(shape):
+    assert shape.type == 'LinearRing'
+    return LinearRing(list(shape.coords)[::-1])
+
+
+def reverse_polygon(shape):
+    assert shape.type == 'Polygon'
+
+    exterior = reverse_ring(shape.exterior)
+    interiors = [reverse_ring(r) for r in shape.interiors]
+
+    return Polygon(exterior, interiors)
+
+
+def make_valid_polygon_flip(shape):
+    assert shape.type == 'Polygon'
+    # to handle cases where the area of the polygon is zero, we need to
+    # manually reverse the coords in the polygon, then buffer(0) it to make it
+    # valid in reverse, then reverse them again to get back to the original,
+    # intended orientation.
+
+    flipped = reverse_polygon(shape)
+    fixed = flipped.buffer(0)
+
+    if fixed.is_empty:
+        return None
+    else:
+        if fixed.type == 'Polygon':
+            return reverse_polygon(fixed)
+        elif fixed.type == 'MultiPolygon':
+            flipped_geoms = []
+            for geom in fixed.geoms:
+                reversed_geom = reverse_polygon(geom)
+                flipped_geoms.append(reversed_geom)
+            return MultiPolygon(flipped_geoms)
+
+
+def area_bounds(shape):
+    if shape.is_empty:
+        return 0
+
+    elif shape.type == 'MultiPolygon':
+        area = 0
+        for geom in shape.geoms:
+            area += area_bounds(geom)
+        return area
+
+    elif shape.type == 'Polygon':
+        minx, miny, maxx, maxy = shape.bounds
+        area = (maxx - minx) * (maxy - miny)
+        return area
+
+    else:
+        assert 'area_bounds: invalid shape type: %s' % shape.type
+
+
+def make_valid_polygon(shape):
+    prev_area = area_bounds(shape)
+    new_shape = shape.buffer(0)
+    assert new_shape.is_valid, \
+        'buffer(0) did not make geometry valid. old shape: %s' % shape.wkt
+    new_area = area_bounds(new_shape)
+
+    if new_area < 0.9 * prev_area:
+        alt_shape = make_valid_polygon_flip(shape)
+        if alt_shape:
+            new_shape = new_shape.union(alt_shape)
+
+    return new_shape
+
+
+def make_valid_multipolygon(shape):
+    new_g = []
+
+    for g in shape.geoms:
+        if g.is_empty:
+            continue
+
+        valid_g = on_invalid_geometry_make_valid(g)
+
+        if valid_g.type == 'MultiPolygon':
+            new_g.extend(valid_g.geoms)
+        else:
+            new_g.append(valid_g)
+
+    return MultiPolygon(new_g)
+
+
+def make_it_valid(shape):
+    if shape.is_empty:
+        return shape
+
+    elif shape.type == 'MultiPolygon':
+        shape = make_valid_multipolygon(shape)
+
+    elif shape.type == 'Polygon':
+        shape = make_valid_polygon(shape)
+
+    return shape

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,11 @@ setup(name='mapbox-vector-tile',
       include_package_data=True,
       zip_safe=False,
       test_suite="setup.test_suite",
-      install_requires=["setuptools", "protobuf", "shapely", "future"]
+      install_requires=[
+          "setuptools",
+          "protobuf",
+          "shapely",
+          "future",
+          "pyclipper"
+      ]
       )


### PR DESCRIPTION
This adds a dependency on [pyclipper](https://pypi.python.org/pypi/pyclipper), a Python wrapper around [Angus Johnson's Clipper](http://www.angusj.com/delphi/clipper.php) library, which performs robust polygon clipping. We can use this library to union a self-intersecting polygon with its reverse and recover all parts of the polygon.

This is a further attempt at #66, and tries to fix that and tilezen/vector-datasource#1075.

Connects to  tilezen/vector-datasource#1075.

@rmarianski could you review, please?
