### PR TITLE
Include LICENSE & CHANGELOG.md in sdist tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md
+include README.md LICENSE CHANGELOG.md


### PR DESCRIPTION
The tarballs on PyPI don't include the LICENSE & CHANGELOG.md files.