### PR TITLE
Enforce winding order optional

### DIFF
--- a/mapbox_vector_tile/__init__.py
+++ b/mapbox_vector_tile/__init__.py
@@ -9,9 +9,9 @@ def decode(tile, y_coord_down=False):
 
 
 def encode(layers, quantize_bounds=None, y_coord_down=False, extents=4096,
-           on_invalid_geometry=None, round_fn=None):
+           on_invalid_geometry=None, round_fn=None, check_winding_order=True):
     vector_tile = encoder.VectorTile(extents, on_invalid_geometry,
-                                     round_fn=round_fn)
+                                     round_fn=round_fn, check_winding_order=check_winding_order)
     if (isinstance(layers, list)):
         for layer in layers:
             vector_tile.addFeatures(layer['features'], layer['name'],

--- a/mapbox_vector_tile/__init__.py
+++ b/mapbox_vector_tile/__init__.py
@@ -11,7 +11,8 @@ def decode(tile, y_coord_down=False):
 def encode(layers, quantize_bounds=None, y_coord_down=False, extents=4096,
            on_invalid_geometry=None, round_fn=None, check_winding_order=True):
     vector_tile = encoder.VectorTile(extents, on_invalid_geometry,
-                                     round_fn=round_fn, check_winding_order=check_winding_order)
+                                     round_fn=round_fn,
+                                     check_winding_order=check_winding_order)
     if (isinstance(layers, list)):
         for layer in layers:
             vector_tile.addFeatures(layer['features'], layer['name'],

--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -53,8 +53,8 @@ class VectorTile:
         rounded = d.quantize(1, rounding=decimal.ROUND_HALF_EVEN)
         return float(rounded)
 
-    def addFeatures(self, features, layer_name='',
-                    quantize_bounds=None, y_coord_down=False, winding_order):
+    def addFeatures(self, features, winding_order, layer_name='',
+                    quantize_bounds=None, y_coord_down=False):
 
         self.layer = self.tile.layers.add()
         self.layer.name = layer_name
@@ -84,7 +84,6 @@ class VectorTile:
 
             if quantize_bounds:
                 shape = self.quantize(shape, quantize_bounds)
-
             if winding_order:
                 shape = self.enforce_winding_order(shape, y_coord_down)
 

--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -32,10 +32,12 @@ class VectorTile:
     """
 
     def __init__(self, extents, on_invalid_geometry=None,
-                 max_geometry_validate_tries=5, round_fn=None):
+                 max_geometry_validate_tries=5, round_fn=None,
+                 winding_order=True):
         self.tile = vector_tile.tile()
         self.extents = extents
         self.on_invalid_geometry = on_invalid_geometry
+        self.winding_order = winding_order
         self.max_geometry_validate_tries = max_geometry_validate_tries
         if round_fn:
             self._round = round_fn
@@ -83,7 +85,8 @@ class VectorTile:
             if quantize_bounds:
                 shape = self.quantize(shape, quantize_bounds)
 
-            shape = self.enforce_winding_order(shape, y_coord_down)
+            if winding_order:
+                shape = self.enforce_winding_order(shape, y_coord_down)
 
             if shape is not None and not shape.is_empty:
                 self.addFeature(feature, shape, y_coord_down)

--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -54,7 +54,7 @@ class VectorTile:
         return float(rounded)
 
     def addFeatures(self, features, layer_name='',
-                    quantize_bounds=None, y_coord_down=False):
+                    quantize_bounds=None, y_coord_down=False, winding_order):
 
         self.layer = self.tile.layers.add()
         self.layer.name = layer_name

--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -33,11 +33,11 @@ class VectorTile:
 
     def __init__(self, extents, on_invalid_geometry=None,
                  max_geometry_validate_tries=5, round_fn=None,
-                 winding_order=True):
+                 check_winding_order=True):
         self.tile = vector_tile.tile()
         self.extents = extents
         self.on_invalid_geometry = on_invalid_geometry
-        self.winding_order = winding_order
+        self.check_winding_order = check_winding_order
         self.max_geometry_validate_tries = max_geometry_validate_tries
         if round_fn:
             self._round = round_fn
@@ -53,7 +53,7 @@ class VectorTile:
         rounded = d.quantize(1, rounding=decimal.ROUND_HALF_EVEN)
         return float(rounded)
 
-    def addFeatures(self, features, winding_order, layer_name='',
+    def addFeatures(self, features, layer_name='',
                     quantize_bounds=None, y_coord_down=False):
 
         self.layer = self.tile.layers.add()
@@ -84,7 +84,7 @@ class VectorTile:
 
             if quantize_bounds:
                 shape = self.quantize(shape, quantize_bounds)
-            if winding_order:
+            if self.check_winding_order:
                 shape = self.enforce_winding_order(shape, y_coord_down)
 
             if shape is not None and not shape.is_empty:


### PR DESCRIPTION
Hello,
Enforce_winding_order function costs about 30% of the overall encoding process. On the other hand, the winding order of the geom can also be enforced in  PostGIS databases through the [ST_ForceRHR()](http://postgis.net/docs/ST_ForceRHR.html) function. For users that wish to do so, having Enforce_winding_order as an optional parameter (activated by default) would mean a substantial performance gain.