### PR TITLE
Use _pb2.py suffix required for protobuf >= 3.0.0.

### DIFF
--- a/mapbox_vector_tile/Mapbox/vector_tile_p3_pb2.py
+++ b/mapbox_vector_tile/Mapbox/vector_tile_p3_pb2.py
@@ -287,26 +287,26 @@ tile = _reflection.GeneratedProtocolMessageType('tile', (_message.Message,), dic
 
   value = _reflection.GeneratedProtocolMessageType('value', (_message.Message,), dict(
     DESCRIPTOR = _TILE_VALUE,
-    __module__ = 'vector_tile_pb2_p3'
+    __module__ = 'vector_tile_p3_pb2'
     # @@protoc_insertion_point(class_scope:mapnik.vector.tile.value)
     ))
   ,
 
   feature = _reflection.GeneratedProtocolMessageType('feature', (_message.Message,), dict(
     DESCRIPTOR = _TILE_FEATURE,
-    __module__ = 'vector_tile_pb2_p3'
+    __module__ = 'vector_tile_p3_pb2'
     # @@protoc_insertion_point(class_scope:mapnik.vector.tile.feature)
     ))
   ,
 
   layer = _reflection.GeneratedProtocolMessageType('layer', (_message.Message,), dict(
     DESCRIPTOR = _TILE_LAYER,
-    __module__ = 'vector_tile_pb2_p3'
+    __module__ = 'vector_tile_p3_pb2'
     # @@protoc_insertion_point(class_scope:mapnik.vector.tile.layer)
     ))
   ,
   DESCRIPTOR = _TILE,
-  __module__ = 'vector_tile_pb2_p3'
+  __module__ = 'vector_tile_p3_pb2'
   # @@protoc_insertion_point(class_scope:mapnik.vector.tile)
   ))
 _sym_db.RegisterMessage(tile)

--- a/mapbox_vector_tile/compat.py
+++ b/mapbox_vector_tile/compat.py
@@ -4,8 +4,8 @@ from builtins import map
 PY3 = sys.version_info[0] == 3
 
 if PY3:
-    from .Mapbox import vector_tile_pb2_p3
-    vector_tile = vector_tile_pb2_p3
+    from .Mapbox import vector_tile_p3_pb2
+    vector_tile = vector_tile_p3_pb2
 else:
     from .Mapbox import vector_tile_pb2
     vector_tile = vector_tile_pb2


### PR DESCRIPTION
Fixes test failures with Python 3:
```
======================================================================
ERROR: test_decoder (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_decoder
Traceback (most recent call last):
  File "/usr/lib/python3.5/unittest/loader.py", line 428, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.5/unittest/loader.py", line 369, in _get_module_from_name
    __import__(name)
  File "/build/mapbox-vector-tile-0.5.0+ds/tests/test_decoder.py", line 8, in <module>
    import mapbox_vector_tile
  File "/build/mapbox-vector-tile-0.5.0+ds/mapbox_vector_tile/__init__.py", line 1, in <module>
    from . import encoder
  File "/build/mapbox-vector-tile-0.5.0+ds/mapbox_vector_tile/encoder.py", line 15, in <module>
    from .compat import PY3, vector_tile, apply_map
  File "/build/mapbox-vector-tile-0.5.0+ds/mapbox_vector_tile/compat.py", line 7, in <module>
    from .Mapbox import vector_tile_pb2_p3
  File "/build/mapbox-vector-tile-0.5.0+ds/mapbox_vector_tile/Mapbox/vector_tile_pb2_p3.py", line 35, in <module>
    type=None),
  File "/usr/lib/python3/dist-packages/google/protobuf/descriptor.py", line 652, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors should not be created directly, but only retrieved from their parent.

======================================================================
ERROR: test_encoder (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_encoder
Traceback (most recent call last):
  File "/usr/lib/python3.5/unittest/loader.py", line 428, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.5/unittest/loader.py", line 369, in _get_module_from_name
    __import__(name)
  File "/build/mapbox-vector-tile-0.5.0+ds/tests/test_encoder.py", line 7, in <module>
    import mapbox_vector_tile
  File "/build/mapbox-vector-tile-0.5.0+ds/mapbox_vector_tile/__init__.py", line 1, in <module>
    from . import encoder
  File "/build/mapbox-vector-tile-0.5.0+ds/mapbox_vector_tile/encoder.py", line 15, in <module>
    from .compat import PY3, vector_tile, apply_map
  File "/build/mapbox-vector-tile-0.5.0+ds/mapbox_vector_tile/compat.py", line 7, in <module>
    from .Mapbox import vector_tile_pb2_p3
  File "/build/mapbox-vector-tile-0.5.0+ds/mapbox_vector_tile/Mapbox/vector_tile_pb2_p3.py", line 35, in <module>
    type=None),
  File "/usr/lib/python3/dist-packages/google/protobuf/descriptor.py", line 652, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors should not be created directly, but only retrieved from their parent.
```

See also: https://github.com/google/protobuf/blob/2fe0556c7abbe31c02147b9171397737a35bfe3b/python/google/protobuf/pyext/descriptor.cc#L94