### PR TITLE
Skip inners which cause exceptions.

### DIFF
--- a/mapbox_vector_tile/polygon.py
+++ b/mapbox_vector_tile/polygon.py
@@ -79,7 +79,17 @@ def _polytree_node_to_shapely(node):
         poly = _contour_to_poly(node.Contour)
         for ch in children:
             inner = _contour_to_poly(ch)
-            diff = poly.difference(inner)
+
+            # the difference of two valid polygons may fail, and in this
+            # situation we'd like to be able to display the polygon anyway.
+            # so we discard the bad inner and continue.
+            #
+            # see test_polygon_inners_crossing_outer for a test case.
+            try:
+                diff = poly.difference(inner)
+            except:
+                continue
+
             if not diff.is_valid:
                 diff = diff.buffer(0)
 

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -188,4 +188,12 @@ class TestPolygonMakeValid(unittest.TestCase):
         self.assertFalse(geom.is_valid)
         fixed = make_it_valid(geom)
         self.assertTrue(fixed.is_valid)
-        self.assertAlmostEqual(1548.08, fixed.area, delta=0.01)
+        # different versions of GEOS hit this bug in slightly different ways,
+        # meaning that some inners get included and some don't, depending on
+        # the version. therefore, we need quite a wide range of acceptable
+        # answers.
+        #
+        # the main part of this polygon (outer - largest inner) has area 1551,
+        # and the smaller inners sum up to area 11, so we'll take +/-6 from
+        # 1545.
+        self.assertAlmostEqual(1545, fixed.area, delta=6)

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -173,3 +173,19 @@ class TestPolygonMakeValid(unittest.TestCase):
         fixed = make_it_valid(geom)
         self.assertTrue(fixed.is_valid)
         self.assertEquals(22, fixed.area)
+
+    def test_polygon_inners_crossing_outer(self):
+        geom = wkt.loads("""POLYGON (
+          (2325 1015, 2329 1021, 2419 1057, 2461 944, 2369 907, 2325 1015),
+          (2329 1012, 2370 909, 2457 944, 2417 1050, 2329 1012),
+          (2410 1053, 2410 1052, 2412 1053, 2411 1054, 2410 1053),
+          (2378 1040, 2378 1039, 2379 1040, 2379 1041, 2378 1040),
+          (2369 1037, 2370 1036, 2371 1036, 2371 1038, 2369 1037),
+          (2361 1034, 2362 1033, 2363 1033, 2363 1034, 2361 1034),
+          (2353 1031, 2354 1029, 2355 1030, 2354 1031, 2353 1031),
+          (2337 1024, 2338 1023, 2339 1023, 2338 1025, 2337 1024)
+        )""")
+        self.assertFalse(geom.is_valid)
+        fixed = make_it_valid(geom)
+        self.assertTrue(fixed.is_valid)
+        self.assertAlmostEqual(1548.08, fixed.area, delta=0.01)


### PR DESCRIPTION
Differencing two polygons can sometimes result in an exception, even if both input polygons are valid. This exception would be propagated and could prevent the tile from being generated. Instead, we skip any inner for which the difference was not computable, just as we already do for any inner which causes the outer to become invalid.