### PR TITLE
Enable Shapely speedups when available

### DIFF
--- a/mapbox_vector_tile/__init__.py
+++ b/mapbox_vector_tile/__init__.py
@@ -2,6 +2,13 @@ from . import encoder
 from . import decoder
 
 
+# Enable Shapely "speedups" if available
+# http://toblerity.org/shapely/manual.html#performance
+from shapely import speedups
+if speedups.available:
+    speedups.enable()
+
+
 def decode(tile, y_coord_down=False):
     vector_tile = decoder.TileData()
     message = vector_tile.getMessage(tile, y_coord_down)


### PR DESCRIPTION
I stumbled across the fact that Shapely has the option to enable "speedups"!

http://toblerity.org/shapely/manual.html#performance
> The shapely.speedups module contains performance enhancements written in C. They are automaticaly installed when Python has access to a compiler and GEOS development headers during installation.

I added a check to run `speedups.enable()` when it's available. It's worth noting that it looks like [Shapely has this enabled by default in versions > 1.6](https://github.com/Toblerity/Shapely/blob/master/CHANGES.txt#L91). I don't see any reason that this change is incompatible with the new default setting, though and this will help everyone who can't/won't/hasn't upgraded Shapely in a while.

In my benchmarking I consistently see about 3 seconds shaved off the benchmark script in this repo ([bench/bench_encode.py](https://github.com/tilezen/mapbox-vector-tile/blob/master/bench/bench_encode.py)). I observe this same performance improvement when using both the Ptyhon protobuf implementation and the [C++ protobuf implementation](https://github.com/tilezen/mapbox-vector-tile#use-native-protobuf-library-for-performance). On my hardware that means an 18 second test becomes a 15 second test (Python protobufs) and a 12 second test becomes a 9 second test (C++ protobufs). So, that's roughly a 16% and 25% relative improvement, respectively.

I created a gist for testing this using Docker and included a few results:
https://gist.github.com/jalessio/7f7a0d73347e51effb11deda3a034f90

