### PR TITLE
Use a separate values index for booleans

### DIFF
--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -66,6 +66,7 @@ class VectorTile:
         self.val_idx = 0
         self.seen_keys_idx = {}
         self.seen_values_idx = {}
+        self.seen_values_bool_idx = {}
 
         for feature in features:
 
@@ -284,8 +285,13 @@ class VectorTile:
 
                 feature.tags.append(self.seen_keys_idx[k])
 
-                if v not in self.seen_values_idx:
-                    self.seen_values_idx[v] = self.val_idx
+                if isinstance(v, bool):
+                    values_idx = self.seen_values_bool_idx
+                else:
+                    values_idx = self.seen_values_idx
+
+                if v not in values_idx:
+                    values_idx[v] = self.val_idx
                     self.val_idx += 1
 
                     val = layer.values.add()
@@ -303,4 +309,4 @@ class VectorTile:
                     elif isinstance(v, float):
                         val.double_value = v
 
-                feature.tags.append(self.seen_values_idx[v])
+                feature.tags.append(values_idx[v])

--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -207,10 +207,10 @@ class VectorTile:
 
         try:
             return load_wkb(geometry_spec)
-        except:
+        except Exception:
             try:
                 return load_wkt(geometry_spec)
-            except:
+            except Exception:
                 return None
 
     def addFeature(self, feature, shape, y_coord_down):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -490,6 +490,29 @@ class TestDifferentGeomFormats(BaseTestCase):
         features = result['foo']['features']
         self.assertEqual(0, len(features))
 
+    def test_encode_1_True_values(self):
+        geometry = 'POINT(0 0)'
+        properties = {
+            'foo': True,
+            'bar': 1,
+        }
+        source = [{
+            'name': 'layer',
+            'features': [{
+                'geometry': geometry,
+                'properties': properties
+            }]
+        }]
+        encoded = encode(source)
+        decoded = decode(encoded)
+        layer = decoded['layer']
+        features = layer['features']
+        act_props = features[0]['properties']
+        self.assertEquals(act_props['foo'], True)
+        self.assertEquals(act_props['bar'], 1)
+        self.assertTrue(isinstance(act_props['foo'], bool))
+        self.assertFalse(isinstance(act_props['bar'], bool))
+
 
 class TestDictGeometries(BaseTestCase):
 


### PR DESCRIPTION
Connects to https://github.com/tilezen/mapbox-vector-tile/issues/96

This prevents collisions between boolean and integer values. In python:
1 == True and 0 == False. But, we don't want these to point to the same
value in the index table.