### PR TITLE
Include vector_tile.proto in sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md LICENSE CHANGELOG.md
+include README.md LICENSE CHANGELOG.md mapbox_vector_tile/Mapbox/*.proto


### PR DESCRIPTION
To make it easier to regenerate the vector_tile Python sources the `.proto` file should be included in the source distribution.

For the Debian package we need to regenerate those files with protobuf 3.6.1 for the ongoing transition for example.

Even better would be to run `protoc` as part of the build, but that requires additional dev dependencies that may not be desirable.