### PR TITLE
Target a major version bump in the next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 1.3.0
+Version 2.0.0
 -------------
 
 *In development*


### PR DESCRIPTION
With dropping python 2, a major version bump seems warranted.
