### PR TITLE
Fix the build system not to install docs into site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
 ]
 include = [
     "mapbox_vector_tile/Mapbox/*.proto",
-    "README.md",
-    "CHANGELOG.md",
+    { path = "README.md", format = "sdist" },
+    { path = "CHANGELOG.md", format = "sdist" },
 ]
 packages = [
     { include = "mapbox_vector_tile" }


### PR DESCRIPTION
Fix `pyproject.toml` not to install `README.md` and `CHANGELOG.md` straight into site-packages directory, i.e. as:

    /usr/lib/python3.12/site-packages/README.md

To do that, explicitly specify `format = "sdist"`, so that the files are included in sdist archives only, and not in wheels, where there would end up being treated as Python packages.