### PR TITLE
Bump protobuf to ^6.31.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-protobuf = "^5.26.1"
+protobuf = "^6.31.0"
 shapely = "^2.0.0"
 pyclipper = "^1.3.0"
 pyproj = { version = "^3.4.1", optional = true }


### PR DESCRIPTION
Hello!

There's a [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2025-4565) with protobuf versions older than 6.31.1. I'd like to propose to make that the minimum version here.

Thanks!